### PR TITLE
feat(data-contracts): add schemas and validation tests

### DIFF
--- a/DATA_CONTRACTS/fixtures/asset.registry.sample.json
+++ b/DATA_CONTRACTS/fixtures/asset.registry.sample.json
@@ -1,1 +1,6 @@
-{ "assets": [] }
+{
+    "version": "1.0.0",
+    "checksum": "17a43504f0462646c9354cce8eec174ca0fda2aa80d7f01283b1b630ef64918a",
+    "chains": [],
+    "assets": []
+}

--- a/DATA_CONTRACTS/schemas/asset.registry.schema.json
+++ b/DATA_CONTRACTS/schemas/asset.registry.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "DATA_CONTRACTS/schemas/asset.registry.schema.json",
+  "type": "object",
+  "required": ["version", "checksum", "chains", "assets"],
+  "properties": {
+    "version": { "type": "string", "description": "semver (x.y.z)" },
+    "checksum": { "type": "string" },
+    "introduced_in": { "type": "string" },
+    "deprecated_in": { "type": "string" },
+    "chains": { "type": "array", "items": { "type": "object" } },
+    "assets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["asset_id"],
+        "properties": {
+          "asset_id": { "type": "string", "description": "opaque id used across system" },
+          "aliases": { "type": "array", "items": { "type": "string" } },
+          "provider_ids": { "type": "object" },
+          "contracts": { "type": "array", "items": { "type": "object" } },
+          "introduced_in": { "type": "string" },
+          "deprecated_in": { "type": "string" },
+          "deprecation_status": { "type": "string" },
+          "superseded_by": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/DATA_CONTRACTS/schemas/price_fx.annotation.schema.json
+++ b/DATA_CONTRACTS/schemas/price_fx.annotation.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "DATA_CONTRACTS/schemas/price_fx.annotation.schema.json",
+  "type": "object",
+  "required": ["price_source", "resolution", "asof"],
+  "properties": {
+    "price_source": { "type": "string" },
+    "resolution": { "type": "string", "enum": ["5m", "1h", "1d"] },
+    "asof": { "type": "string", "format": "date-time" },
+    "fx_source": { "type": ["string", "null"] },
+    "fx_rate": { "type": ["number", "null"] },
+    "drift_bps": { "type": ["number", "null"] },
+    "flags": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["DELAYED_FX"] }
+    }
+  }
+}

--- a/DATA_CONTRACTS/schemas/transactions.v1.1.schema.json
+++ b/DATA_CONTRACTS/schemas/transactions.v1.1.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "DATA_CONTRACTS/schemas/transactions.v1.1.schema.json",
+  "type": "object",
+  "required": ["id", "timestamp", "action", "asset_id", "quantity", "account"],
+  "properties": {
+    "id": { "type": "string", "format": "uuid", "description": "UUIDv7" },
+    "timestamp": { "type": "string", "format": "date-time", "description": "UTC ISO" },
+    "action": {
+      "type": "string",
+      "enum": [
+        "BUY",
+        "SELL",
+        "TRANSFER_IN",
+        "TRANSFER_OUT",
+        "FEE",
+        "STAKING_REWARD",
+        "AIRDROP",
+        "INCOME"
+      ]
+    },
+    "asset_id": { "type": "string" },
+    "quantity": { "type": "number" },
+    "unit_price_usd": { "type": ["number", "null"] },
+    "fee_asset": { "type": ["string", "null"] },
+    "fee_amount": { "type": ["number", "null"] },
+    "account": { "type": "string" },
+    "wallet": { "type": ["string", "null"] },
+    "venue": { "type": ["string", "null"] },
+    "tx_hash": { "type": ["string", "null"] },
+    "external_id": { "type": ["string", "null"] },
+    "notes": { "type": ["string", "null"] }
+  },
+  "x-idempotency": {
+    "oneOf": [
+      { "required": ["account", "tx_hash"] },
+      { "required": ["external_id"] },
+      { "required": ["id"] }
+    ]
+  }
+}

--- a/tests/data_contracts/test_asset_registry_schema.py
+++ b/tests/data_contracts/test_asset_registry_schema.py
@@ -1,0 +1,26 @@
+"""Validate asset registry sample against schema and checksum rules."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from jsonschema import Draft7Validator
+from packaging.version import Version
+
+SCHEMA_PATH = Path("DATA_CONTRACTS/schemas/asset.registry.schema.json")
+SAMPLE_JSON = Path("DATA_CONTRACTS/fixtures/asset.registry.sample.json")
+
+
+def test_asset_registry_sample_validates_and_checks_checksum() -> None:
+    schema = json.loads(SCHEMA_PATH.read_text())
+    data = json.loads(SAMPLE_JSON.read_text())
+
+    Draft7Validator(schema).validate(data)
+    Version(data["version"])
+
+    payload = {key: data[key] for key in ["chains", "assets"]}
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    checksum = hashlib.sha256(canonical).hexdigest()
+    assert data["checksum"] == checksum

--- a/tests/data_contracts/test_parquet_partitions.py
+++ b/tests/data_contracts/test_parquet_partitions.py
@@ -1,0 +1,32 @@
+"""Ensure Parquet datasets use dt/asset_id partition layout."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+
+def test_parquet_partition_layout(tmp_path: Path) -> None:
+    table = pa.table(
+        {
+            "t": [0],
+            "o": [1.0],
+            "h": [1.0],
+            "l": [1.0],
+            "c": [1.0],
+            "v": [1.0],
+            "dt": ["2024-01-01"],
+            "asset_id": ["btc"],
+        }
+    )
+    root = tmp_path / "dataset"
+    pq.write_to_dataset(table, root_path=root, partition_cols=["dt", "asset_id"])
+
+    files = list(root.rglob("*.parquet"))
+    assert files, "No Parquet files written"
+    for file in files:
+        parts = file.relative_to(root).parts
+        assert parts[0].startswith("dt=")
+        assert parts[1].startswith("asset_id=")

--- a/tests/data_contracts/test_price_fx_schema.py
+++ b/tests/data_contracts/test_price_fx_schema.py
@@ -1,0 +1,27 @@
+"""Validate price/FX annotation schema."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator, ValidationError
+
+SCHEMA_PATH = Path("DATA_CONTRACTS/schemas/price_fx.annotation.schema.json")
+
+
+def test_price_fx_annotation_structure() -> None:
+    schema = json.loads(SCHEMA_PATH.read_text())
+    validator = Draft7Validator(schema)
+
+    good = {
+        "price_source": "manual",
+        "resolution": "1d",
+        "asof": "2024-01-01T00:00:00Z",
+    }
+    validator.validate(good)
+
+    bad = {"price_source": "manual"}
+    with pytest.raises(ValidationError):
+        validator.validate(bad)

--- a/tests/data_contracts/test_transactions_schema.py
+++ b/tests/data_contracts/test_transactions_schema.py
@@ -1,0 +1,35 @@
+"""Validate transactions CSV against schema."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+from jsonschema import Draft7Validator
+
+SCHEMA_PATH = Path("DATA_CONTRACTS/schemas/transactions.v1.1.schema.json")
+SAMPLE_CSV = Path("DATA_CONTRACTS/fixtures/transactions.v1.1.sample.csv")
+
+
+def test_transactions_sample_csv_validates_schema() -> None:
+    schema = json.loads(SCHEMA_PATH.read_text())
+    validator = Draft7Validator(schema)
+
+    with SAMPLE_CSV.open(newline="") as handle:
+        reader = csv.DictReader(handle)
+        assert reader.fieldnames == [
+            "id",
+            "timestamp",
+            "action",
+            "asset_id",
+            "quantity",
+            "unit_price_usd",
+            "account",
+        ]
+        for row in reader:
+            if row["quantity"]:
+                row["quantity"] = float(row["quantity"])
+            if row["unit_price_usd"]:
+                row["unit_price_usd"] = float(row["unit_price_usd"])
+            validator.validate(row)


### PR DESCRIPTION
## Summary
- add JSON schemas for transactions v1.1, asset registry, and price/FX annotations
- validate sample data and parquet partition layout with new tests

## Testing
- `make check`
- `make test`
- `pytest --override-ini addopts="" tests/data_contracts`


------
https://chatgpt.com/codex/tasks/task_e_68c636cee1488322b5e55c549fb3ac2f