### PR TITLE
test(backend): add capabilities env integration test

### DIFF
--- a/backend/tests/integration/test_health_checks.py
+++ b/backend/tests/integration/test_health_checks.py
@@ -1,0 +1,27 @@
+import os
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.parametrize(
+    "env, expected_eth, expected_btc",
+    [
+        ({"ETHERSCAN_API_KEY": "x", "MEMPOOL_SPACE_API_KEY": "y"}, True, True),
+        ({"ETHERSCAN_API_KEY": "x"}, True, False),
+        ({"MEMPOOL_SPACE_API_KEY": "y"}, False, True),
+        ({}, False, False),
+    ],
+)
+def test_capabilities_flags_reflect_env(
+    client: TestClient, env: dict[str, str], expected_eth: bool, expected_btc: bool
+) -> None:
+    """Ensure capability flags mirror presence of provider API keys."""
+    with patch.dict(os.environ, env, clear=True):
+        response = client.get("/capabilities")
+        body = response.json()
+        assert body["eth_gas"]["enabled"] is expected_eth
+        assert body["btc_mempool"]["enabled"] is expected_btc


### PR DESCRIPTION
## Summary
- add integration test for capabilities endpoint toggling ETHERSCAN_API_KEY and MEMPOOL_SPACE_API_KEY

## Testing
- `make check`
- `pytest backend/tests/integration/test_health_checks.py`
- `make test` *(fails: frontend vitest run has failing node module tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cfa63d1083228a9ee76ef940be18