### PR TITLE
feat(backend): add env config loader with tests

### DIFF
--- a/backend/app/config_env.py
+++ b/backend/app/config_env.py
@@ -1,0 +1,61 @@
+"""Environment variable configuration for the backend service."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Typed runtime settings loaded from environment variables."""
+
+    api_host: str
+    api_port: int
+    redis_url: str
+    debug: bool
+
+
+def _getenv(
+    name: str,
+    *,
+    default: str | None = None,
+    cast: type = str,
+    required: bool = False,
+):
+    """Fetch an environment variable and cast it to the given type.
+
+    Args:
+        name: The environment variable name.
+        default: Default value if the variable is not set.
+        cast: Type to cast the variable to. Booleans accept common true values.
+        required: If True, raises RuntimeError when the variable is missing.
+
+    Returns:
+        The cast value or the default when provided.
+    """
+
+    raw = os.getenv(name)
+    if raw is None:
+        if required:
+            raise RuntimeError(f"{name} environment variable is required")
+        raw = default
+    if raw is None:
+        return None
+    if cast is bool:
+        return raw.lower() in {"1", "true", "t", "yes", "on"}
+    try:
+        return cast(raw)
+    except Exception as exc:
+        raise RuntimeError(f"invalid value for {name}") from exc
+
+
+def load() -> Settings:
+    """Load typed settings from environment variables."""
+
+    return Settings(
+        api_host=_getenv("API_HOST", default="127.0.0.1"),
+        api_port=_getenv("API_PORT", default="8000", cast=int),
+        redis_url=_getenv("REDIS_URL", required=True),
+        debug=_getenv("DEBUG", default="0", cast=bool),
+    )

--- a/backend/tests/unit/test_config_env.py
+++ b/backend/tests/unit/test_config_env.py
@@ -1,0 +1,42 @@
+import pytest
+from app.config_env import Settings, load
+
+pytestmark = pytest.mark.unit
+
+
+def test_load_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Defaults apply when optional vars unset."""
+    monkeypatch.setenv("REDIS_URL", "redis://127.0.0.1:6379/0")
+    monkeypatch.delenv("API_HOST", raising=False)
+    monkeypatch.delenv("API_PORT", raising=False)
+    monkeypatch.delenv("DEBUG", raising=False)
+
+    cfg = load()
+
+    assert cfg == Settings(
+        api_host="127.0.0.1",
+        api_port=8000,
+        redis_url="redis://127.0.0.1:6379/0",
+        debug=False,
+    )
+
+
+def test_load_env_casts_types(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Environment values are cast to declared types."""
+    monkeypatch.setenv("REDIS_URL", "redis://127.0.0.1:6379/1")
+    monkeypatch.setenv("API_PORT", "9000")
+    monkeypatch.setenv("DEBUG", "1")
+
+    cfg = load()
+
+    assert cfg.api_host == "127.0.0.1"  # default unaffected
+    assert cfg.api_port == 9000
+    assert cfg.debug is True
+
+
+def test_missing_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Required variables raise RuntimeError when absent."""
+    monkeypatch.delenv("REDIS_URL", raising=False)
+
+    with pytest.raises(RuntimeError):
+        load()


### PR DESCRIPTION
## Summary
- add environment configuration loader with default binding and type conversions
- test config loader for defaults, type casting, and required var errors

## Testing
- `make check`
- `make test` *(fails: msw dependency tests in frontend)*
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_68c6d3387e2483228683e3ad1965c9ad