### PR TITLE
feat(backend): redact secrets and enforce localhost binding

### DIFF
--- a/backend/app/config_env.py
+++ b/backend/app/config_env.py
@@ -52,9 +52,12 @@ def _getenv(
 
 def load() -> Settings:
     """Load typed settings from environment variables."""
+    host = _getenv("API_HOST", default="127.0.0.1")
+    if host != "127.0.0.1":  # security guardrail: bind localhost only
+        raise RuntimeError("API_HOST must be 127.0.0.1")
 
     return Settings(
-        api_host=_getenv("API_HOST", default="127.0.0.1"),
+        api_host=host,
         api_port=_getenv("API_PORT", default="8000", cast=int),
         redis_url=_getenv("REDIS_URL", required=True),
         debug=_getenv("DEBUG", default="0", cast=bool),

--- a/backend/app/logging_utils.py
+++ b/backend/app/logging_utils.py
@@ -1,0 +1,41 @@
+"""Application logging utilities with secret redaction."""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+
+SECRET_NAME_RE = re.compile(r".*_(?:KEY|TOKEN)$")
+
+
+class SecretFilter(logging.Filter):
+    """Redact secret environment values from log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        for name, value in os.environ.items():
+            if SECRET_NAME_RE.match(name) and value:
+                message = message.replace(value, "[REDACTED]")
+        record.msg = message
+        record.args = ()
+        return True
+
+
+def configure_logging(logger: logging.Logger | None = None) -> logging.Logger:
+    """Configure logging with secret redaction filter.
+
+    Args:
+        logger: Optional existing logger to configure.
+
+    Returns:
+        Configured logger instance.
+    """
+
+    log = logger or logging.getLogger("app")
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    handler.addFilter(SecretFilter())
+    log.addHandler(handler)
+    log.setLevel(logging.INFO)
+    return log

--- a/backend/tests/unit/test_logging_and_binding.py
+++ b/backend/tests/unit/test_logging_and_binding.py
@@ -1,0 +1,39 @@
+import logging
+import os
+
+import pytest
+
+from app.config_env import load
+from app.logging_utils import configure_logging
+
+pytestmark = pytest.mark.unit
+
+
+def test_logging_redacts_secrets(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Secret env vars are not exposed in logs."""
+    monkeypatch.setenv("API_KEY", "supersecret")
+    monkeypatch.setenv("SERVICE_TOKEN", "tok123")
+    logger = configure_logging(logging.getLogger("test_logger"))
+
+    with caplog.at_level(logging.INFO):
+        logger.info(
+            "API_KEY=%s SERVICE_TOKEN=%s",
+            os.getenv("API_KEY"),
+            os.getenv("SERVICE_TOKEN"),
+        )
+
+    output = caplog.text
+    assert "supersecret" not in output
+    assert "tok123" not in output
+    assert "API_KEY=[REDACTED]" in output
+    assert "SERVICE_TOKEN=[REDACTED]" in output
+
+
+def test_load_rejects_non_local_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-local API_HOST values are rejected."""
+    monkeypatch.setenv("REDIS_URL", "redis://127.0.0.1:6379/0")
+    monkeypatch.setenv("API_HOST", "0.0.0.0")
+    with pytest.raises(RuntimeError):
+        load()


### PR DESCRIPTION
## Summary
- enforce backend API_HOST to 127.0.0.1
- add logging utils with secret redaction filter
- test secret redaction and host binding rules

## Testing
- `make check`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68c6d7a3b2fc8322aea3591f7dba17a4