### PR TITLE
test(registry): validate assets and uuidv7 helper

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package marker for relative imports."""

--- a/tests/data_contracts/test_registry_assets_json.py
+++ b/tests/data_contracts/test_registry_assets_json.py
@@ -1,0 +1,27 @@
+"""Validate registry assets file against schema and UUIDv7 requirements."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator
+
+from tests.utils import assert_uuid7
+
+SCHEMA_PATH = Path("DATA_CONTRACTS/schemas/asset.registry.schema.json")
+REGISTRY_PATH = Path("registry/assets.json")
+
+
+def test_registry_assets_json_validates_and_uuidv7() -> None:
+    schema = json.loads(SCHEMA_PATH.read_text())
+    data = json.loads(REGISTRY_PATH.read_text())
+    Draft7Validator(schema).validate(data)
+    for asset in data["assets"]:
+        assert_uuid7(asset["asset_id"])
+
+
+def test_invalid_uuid_rejected() -> None:
+    with pytest.raises(AssertionError):
+        assert_uuid7("00000000-0000-7000-8000-00000000000")

--- a/tests/test_fixture_utils.py
+++ b/tests/test_fixture_utils.py
@@ -1,9 +1,15 @@
 from io import BytesIO
 
 import pandas as pd
+import pytest
 
-from tests.utils import (generate_uuid7, read_fixture, simulate_db_state,
-                         simulate_redis_state)
+from tests.utils import (
+    assert_uuid7,
+    generate_uuid7,
+    read_fixture,
+    simulate_db_state,
+    simulate_redis_state,
+)
 
 
 def test_read_fixture_json():
@@ -24,7 +30,12 @@ def test_read_fixture_parquet():
 
 def test_generate_uuid7():
     uid = generate_uuid7()
-    assert len(uid) == 36 and uid[14] == "7"
+    assert_uuid7(uid)
+
+
+def test_assert_uuid7_invalid():
+    with pytest.raises(AssertionError):
+        assert_uuid7("not-a-uuid")
 
 
 def test_simulated_states():

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import re
 import time
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -46,9 +47,30 @@ def generate_uuid7() -> str:
     time_high = ts_hex[:8]
     time_mid = ts_hex[8:12]
     time_low = ts_hex[12:15]
-    rand_hex = os.urandom(10).hex()
-    variant = "8"
-    return f"{time_high}-{time_mid}-7{time_low}-{variant}{rand_hex[:3]}-{rand_hex[3:]}"
+    rand_hex = os.urandom(8).hex()
+    variant = "8"  # '10xx' variant
+    return (
+        f"{time_high}-{time_mid}-7{time_low}-{variant}{rand_hex[:3]}-{rand_hex[3:15]}"
+    )
+
+
+UUID_V7_PATTERN = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+
+def assert_uuid7(value: str) -> None:
+    """Assert that ``value`` is a valid UUIDv7 string.
+
+    Args:
+        value: UUID string to validate.
+
+    Raises:
+        AssertionError: If the value does not match UUIDv7 format.
+    """
+
+    if not UUID_V7_PATTERN.fullmatch(value):
+        raise AssertionError(f"{value!r} is not a valid UUIDv7")
 
 
 def simulate_redis_state(initial: Optional[Dict[str, str]] = None) -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- add regex-based UUIDv7 assertion and fix generator
- validate registry/assets.json against asset.registry.schema.json
- expand tests for helper

## Testing
- `make check`
- `make test` *(fails: ENOENT in frontend dependency tests)*
- `PYTEST_ADDOPTS='--cov=tests --cov-fail-under=0' pytest tests/test_fixture_utils.py tests/data_contracts/test_registry_assets_json.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6e1a543748322a15381b0590b6078