### PR TITLE
test(ops): verify docker service health

### DIFF
--- a/tests/fixtures/docker/ps_all_healthy.json
+++ b/tests/fixtures/docker/ps_all_healthy.json
@@ -1,0 +1,5 @@
+[
+  {"Service": "frontend", "State": "running", "Health": "healthy"},
+  {"Service": "api", "State": "running", "Health": "healthy"},
+  {"Service": "redis", "State": "running", "Health": "healthy"}
+]

--- a/tests/fixtures/docker/ps_missing_service.json
+++ b/tests/fixtures/docker/ps_missing_service.json
@@ -1,0 +1,4 @@
+[
+  {"Service": "frontend", "State": "running", "Health": "healthy"},
+  {"Service": "api", "State": "running", "Health": "healthy"}
+]

--- a/tests/fixtures/docker/ps_unhealthy.json
+++ b/tests/fixtures/docker/ps_unhealthy.json
@@ -1,0 +1,5 @@
+[
+  {"Service": "frontend", "State": "running", "Health": "healthy"},
+  {"Service": "api", "State": "running", "Health": "unhealthy"},
+  {"Service": "redis", "State": "running", "Health": "healthy"}
+]

--- a/tests/test_docker_compose_health.py
+++ b/tests/test_docker_compose_health.py
@@ -1,0 +1,43 @@
+"""Tests for docker compose service health parsing."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import pytest
+
+from tests.utils import read_fixture
+
+REQUIRED_SERVICES = {"frontend", "api", "redis"}
+
+
+def _load_ps_fixture(name: str) -> list[dict[str, str]]:
+    """Load simulated ``docker compose ps --format json`` output."""
+    data = read_fixture(f"docker/{name}")
+    assert isinstance(data, list)
+    return data
+
+
+def _assert_services_healthy(data: Iterable[dict[str, str]]) -> None:
+    """Assert required services exist and report ``healthy`` status."""
+    services = {entry["Service"]: entry.get("Health") for entry in data}
+    missing = REQUIRED_SERVICES - services.keys()
+    unhealthy = {
+        svc
+        for svc, health in services.items()
+        if svc in REQUIRED_SERVICES and health != "healthy"
+    }
+    if missing or unhealthy:
+        raise AssertionError(f"missing={sorted(missing)} unhealthy={sorted(unhealthy)}")
+
+
+def test_required_services_healthy() -> None:
+    data = _load_ps_fixture("ps_all_healthy.json")
+    _assert_services_healthy(data)
+
+
+@pytest.mark.parametrize("fixture", ["ps_missing_service.json", "ps_unhealthy.json"])
+def test_missing_or_unhealthy_services_fail(fixture: str) -> None:
+    data = _load_ps_fixture(fixture)
+    with pytest.raises(AssertionError):
+        _assert_services_healthy(data)


### PR DESCRIPTION
## Summary
- add fixtures simulating `docker compose ps` output
- test required compose services report healthy

## Testing
- `python -m flake8 --max-line-length=100 tests/test_docker_compose_health.py tests/utils/__init__.py`
- `make check`
- `make test` *(fails: snapshots 42 failed, Test Files 100 failed | 212 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6edcb06f08322b217393083bb3c63