### PR TITLE
feat: degrade health on Redis failure

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
   "uvicorn>=0.30.0",
   "pydantic>=2.8.0",
   "python-multipart>=0.0.7",
+  "redis>=5.0.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/integration/test_health_checks.py
+++ b/backend/tests/integration/test_health_checks.py
@@ -1,8 +1,9 @@
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+from redis.exceptions import ConnectionError
 
 pytestmark = pytest.mark.integration
 
@@ -25,3 +26,31 @@ def test_capabilities_flags_reflect_env(
         body = response.json()
         assert body["eth_gas"]["enabled"] is expected_eth
         assert body["btc_mempool"]["enabled"] is expected_btc
+
+
+def test_health_ok_when_redis_ping_succeeds(client: TestClient) -> None:
+    """Health endpoint returns ok status when Redis ping succeeds."""
+
+    mock_redis = MagicMock()
+    mock_redis.ping.return_value = True
+    with patch("app.main.get_redis_client", return_value=mock_redis), patch.dict(
+        os.environ, {"REDIS_URL": "redis://127.0.0.1:6379/0"}, clear=True
+    ):
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_health_degraded_when_redis_ping_fails(client: TestClient) -> None:
+    """Health endpoint degrades when Redis ping raises an exception."""
+
+    mock_redis = MagicMock()
+    mock_redis.ping.side_effect = ConnectionError("boom")
+    with patch("app.main.get_redis_client", return_value=mock_redis), patch.dict(
+        os.environ, {"REDIS_URL": "redis://127.0.0.1:6379/0"}, clear=True
+    ):
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "degraded"


### PR DESCRIPTION
## Summary
- ping Redis in health check and degrade status on failures
- test successful and failed Redis pings via mocked client
- add redis dependency

## Testing
- `make check`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68c6fa6fb0d0832298c6323bb1ef4601