### PR TITLE
feat(backend): add FX client with retries and breaker

### DIFF
--- a/backend/app/providers/__init__.py
+++ b/backend/app/providers/__init__.py
@@ -1,0 +1,2 @@
+"""Provider client implementations for external services."""
+

--- a/backend/app/providers/fx.py
+++ b/backend/app/providers/fx.py
@@ -1,0 +1,99 @@
+"""FX rate client with timeout, retry, and circuit breaker logic."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+
+
+class CircuitBreakerOpen(Exception):
+    """Raised when the circuit breaker is open and calls are blocked."""
+
+
+@dataclass
+class FXClient:
+    """Simple FX client enforcing timeout, retries, and circuit breaker.
+
+    Parameters
+    ----------
+    base_url: str
+        Base URL for the FX service.
+    timeout: float
+        Request timeout in seconds.
+    retries: int
+        Number of retry attempts for failed requests.
+    breaker_threshold: int
+        Consecutive failures to open the circuit breaker.
+    reset_timeout: float
+        Seconds after which an open breaker resets.
+    transport: Optional[httpx.BaseTransport]
+        Optional custom transport for testing/mocking.
+    """
+
+    base_url: str
+    timeout: float = 5.0
+    retries: int = 3
+    breaker_threshold: int = 5
+    reset_timeout: float = 60.0
+    transport: Optional[httpx.BaseTransport] = None
+
+    _failures: int = 0
+    _opened_at: Optional[float] = None
+
+    def _breaker_open(self) -> bool:
+        """Return True if breaker is currently open."""
+        if self._opened_at is None:
+            return False
+        if time.time() - self._opened_at > self.reset_timeout:
+            self._failures = 0
+            self._opened_at = None
+            return False
+        return True
+
+    async def get_rate(self, base: str, quote: str) -> float:
+        """Fetch FX rate from base to quote.
+
+        Raises
+        ------
+        CircuitBreakerOpen
+            If the circuit breaker is open.
+        httpx.RequestError
+            On network-related errors.
+        httpx.HTTPStatusError
+            If the response status is not 200.
+        KeyError
+            If the expected rate field is missing.
+        """
+
+        if self._breaker_open():
+            raise CircuitBreakerOpen("circuit breaker open")
+
+        url = f"{self.base_url}/latest?base={base}&symbols={quote}"
+        last_exc: Exception | None = None
+
+        for _ in range(self.retries):
+            try:
+                async with httpx.AsyncClient(transport=self.transport) as client:
+                    response = await client.get(url, timeout=self.timeout)
+                response.raise_for_status()
+                data = response.json()
+                rate = float(data["rates"][quote])
+                # Reset failure count on success
+                self._failures = 0
+                self._opened_at = None
+                return rate
+            except (httpx.RequestError, httpx.HTTPStatusError, KeyError) as exc:
+                last_exc = exc
+                # Yield control to allow cooperative multitasking
+                await asyncio.sleep(0)
+
+        # All retries exhausted -> record failure
+        self._failures += 1
+        if self._failures >= self.breaker_threshold:
+            self._opened_at = time.time()
+        assert last_exc is not None
+        raise last_exc

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "redis>=5.0.0",
   "sqlalchemy>=2.0.29",
   "aiosqlite>=0.19.0",
+  "httpx>=0.27.0",
 ]
 
 [project.optional-dependencies]
@@ -23,7 +24,6 @@ test = [
   "fakeredis",
   "openapi-core>=0.19.0",
   "flake8",
-  "httpx",
 ]
 
 [tool.uv]

--- a/backend/tests/unit/test_fx_client.py
+++ b/backend/tests/unit/test_fx_client.py
@@ -1,0 +1,75 @@
+import httpx
+import pytest
+
+from app.providers.fx import CircuitBreakerOpen, FXClient
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_retries_and_timeout():
+    calls = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        raise httpx.ReadTimeout("timeout", request=request)
+
+    transport = httpx.MockTransport(handler)
+    client = FXClient(
+        base_url="https://fx.local",
+        timeout=0.01,
+        retries=3,
+        breaker_threshold=5,
+        transport=transport,
+    )
+
+    with pytest.raises(httpx.ReadTimeout):
+        await client.get_rate("USD", "EUR")
+
+    assert calls == 3  # retries honoured
+    assert client.timeout == 0.01
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_opens():
+    calls = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(500)
+
+    transport = httpx.MockTransport(handler)
+    client = FXClient(
+        base_url="https://fx.local",
+        timeout=0.01,
+        retries=1,
+        breaker_threshold=1,
+        transport=transport,
+    )
+
+    # First call fails and opens breaker
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.get_rate("USD", "EUR")
+    assert calls == 1
+
+    # Subsequent call is blocked by breaker (no additional HTTP call)
+    with pytest.raises(CircuitBreakerOpen):
+        await client.get_rate("USD", "EUR")
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_success_path():
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"rates": {"EUR": 0.9}})
+
+    transport = httpx.MockTransport(handler)
+    client = FXClient(
+        base_url="https://fx.local",
+        transport=transport,
+    )
+
+    rate = await client.get_rate("USD", "EUR")
+    assert rate == pytest.approx(0.9)


### PR DESCRIPTION
## Summary
- add FX client supporting timeouts, retries, and circuit breaker
- test FX client behaviors including retries, timeouts, and breaker open state
- include httpx dependency for backend

## Testing
- `make check`
- `pytest -c /dev/null backend/tests/unit/test_fx_client.py`
- `make test` *(fails: No module named 'jsonschema', No module named 'sqlalchemy'; frontend tests also fail)*

------
https://chatgpt.com/codex/tasks/task_e_68c7025c9cf48322a956687460851c76