### PR TITLE
feat(backend): enforce localhost-only CORS policy

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,14 +2,23 @@ import os
 import time
 from typing import Annotated, Awaitable, Callable, List
 
+from app import config_env
 from fastapi import Depends, FastAPI, Header, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
 from redis import Redis
 
-from app import config_env
-
 app = FastAPI(title="Crypto Analytics BFF", version="0.1.0")
+
+ALLOWED_ORIGINS = ["http://127.0.0.1:3000", "http://localhost:3000"]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 START = time.time()
 

--- a/backend/tests/unit/test_cors.py
+++ b/backend/tests/unit/test_cors.py
@@ -1,0 +1,16 @@
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.unit
+
+
+def test_cors_allows_local_origin(client: TestClient) -> None:
+    response = client.get("/health", headers={"Origin": "http://127.0.0.1:3000"})
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "http://127.0.0.1:3000"
+
+
+def test_cors_blocks_external_origin(client: TestClient) -> None:
+    response = client.get("/health", headers={"Origin": "http://evil.com"})
+    assert response.status_code == 200
+    assert "access-control-allow-origin" not in response.headers


### PR DESCRIPTION
## Summary
- restrict CORS to localhost origins
- add tests covering allowed and disallowed origins

## Testing
- `make check`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68c70594d090832295c910ba1b06c089