### PR TITLE
Reject malicious string payloads with structured errors

### DIFF
--- a/backend/tests/unit/test_input_sanitization.py
+++ b/backend/tests/unit/test_input_sanitization.py
@@ -1,0 +1,27 @@
+from urllib.parse import quote
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.unit
+
+
+def test_asset_candles_rejects_sql_payload(client: TestClient) -> None:
+    payload = quote("1 OR 1=1", safe="")
+    response = client.get(f"/assets/{payload}/candles")
+    assert response.status_code == 400
+    body = response.json()
+    assert body["code"] == "client_invalid_contract"
+
+
+def test_import_rejects_xss_payload(client: TestClient) -> None:
+    payload = "<script>alert('x')</script>"
+    files = {"file": ("test.csv", "col\n1\n", "text/csv")}
+    response = client.post(
+        "/portfolio/holdings/import",
+        headers={"Idempotency-Key": payload},
+        files=files,
+    )
+    assert response.status_code == 400
+    body = response.json()
+    assert body["code"] == "client_invalid_contract"


### PR DESCRIPTION
## Summary
- validate asset_id path parameters against a safe regex
- return structured ErrorResponse for invalid requests
- test rejection of SQL and XSS payloads

## Testing
- `make check`
- `make test` *(fails: missing dependencies and frontend test failures)*
- `pytest backend/tests/unit/test_input_sanitization.py` *(fails: coverage threshold unmet)*

------
https://chatgpt.com/codex/tasks/task_e_68c707d72bfc8322b262dbbbbd4363b5