### PR TITLE
feat(fx): add deterministic FX rate endpoint

### DIFF
--- a/backend/app/fx_stub.py
+++ b/backend/app/fx_stub.py
@@ -1,0 +1,32 @@
+"""Deterministic FX rate stub for testing.
+
+Provides stable exchange rates based on currency pairs to avoid external
+network calls during development and tests.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def deterministic_rate(base: str, quote: str) -> float:
+    """Return a deterministic FX rate for the currency pair.
+
+    Parameters
+    ----------
+    base: str
+        Base currency code (e.g., ``'USD'``).
+    quote: str
+        Quote currency code (e.g., ``'EUR'``).
+
+    Returns
+    -------
+    float
+        Pseudo exchange rate in the range ``[0.5, 1.5)`` derived from a
+        SHA-256 hash of the pair. The rate is deterministic for the same
+        inputs to ensure reproducible calculations in tests.
+    """
+
+    digest = hashlib.sha256(f"{base}:{quote}".encode()).digest()
+    value = int.from_bytes(digest[:8], "big")
+    return round(0.5 + (value % 1000) / 1000, 6)

--- a/backend/tests/unit/test_fx_endpoint.py
+++ b/backend/tests/unit/test_fx_endpoint.py
@@ -1,0 +1,31 @@
+import httpx
+import pytest
+from app.fx_stub import deterministic_rate
+from app.main import app
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_fx_endpoint_returns_deterministic_rate_and_conversions() -> None:
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp_eur = await client.get("/fx/USD/EUR")
+        resp_jpy = await client.get("/fx/USD/JPY")
+
+    data_eur = resp_eur.json()
+    data_jpy = resp_jpy.json()
+
+    expected_eur = deterministic_rate("USD", "EUR")
+    expected_jpy = deterministic_rate("USD", "JPY")
+
+    assert data_eur["rate"] == pytest.approx(expected_eur)
+    assert data_jpy["rate"] == pytest.approx(expected_jpy)
+
+    usd_amount = 10.0
+    eur_converted = usd_amount * data_eur["rate"]
+    jpy_converted = usd_amount * data_jpy["rate"]
+
+    assert eur_converted == pytest.approx(usd_amount * expected_eur)
+    assert jpy_converted == pytest.approx(usd_amount * expected_jpy)
+    assert eur_converted != pytest.approx(jpy_converted)


### PR DESCRIPTION
## Summary
- add deterministic FX rate stub and expose `/fx/{base}/{quote}` endpoint
- cover conversions with unit test for stable downstream calculations

## Testing
- `python -m flake8 backend/app/main.py backend/app/fx_stub.py backend/tests/unit/test_fx_endpoint.py --max-line-length=100`
- `pytest backend/tests -q`
- `make check`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c7224be3c48322a934407327633e0d