### PR TITLE
feat(rate-limiting): add Redis token bucket with adaptive clamps

### DIFF
--- a/backend/app/rate_limiting/__init__.py
+++ b/backend/app/rate_limiting/__init__.py
@@ -1,0 +1,57 @@
+"""Rate limiting utilities exposing high-level APIs."""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from redis import Redis
+
+from .adaptive_clamps import AdaptiveClamp
+from .token_bucket import TokenBucket
+
+_bucket: Optional[TokenBucket] = None
+_clamp = AdaptiveClamp()
+
+
+def init(
+    redis_client: Redis,
+    capacity: int,
+    refill_rate: float,
+    *,
+    time_func: Callable[[], float] | None = None,
+) -> None:
+    """Initialize token bucket with Redis client.
+
+    Parameters
+    ----------
+    redis_client:
+        Redis connection used for token storage.
+    capacity:
+        Maximum number of tokens in each bucket.
+    refill_rate:
+        Tokens added per second.
+    time_func:
+        Optional time provider for tests.
+    """
+
+    global _bucket
+    _bucket = TokenBucket(redis_client, capacity, refill_rate, time_func=time_func)
+
+
+# Security: Public API to acquire tokens. Relies on prior :func:`init` call.
+def acquire(provider: str, route: str, tokens: int = 1) -> bool:
+    """Acquire tokens for ``provider`` and ``route``.
+
+    Returns ``True`` if the call is allowed, ``False`` otherwise.
+    """
+
+    if _bucket is None:  # pragma: no cover - defensive
+        raise RuntimeError("token bucket not initialized")
+    key = f"{provider}:{route}"
+    return _bucket.acquire(key, tokens)
+
+
+def adjust_clamp(provider: str, success: bool) -> float:
+    """Adjust and return the clamp for ``provider``."""
+
+    return _clamp.adjust(provider, success)

--- a/backend/app/rate_limiting/adaptive_clamps.py
+++ b/backend/app/rate_limiting/adaptive_clamps.py
@@ -1,0 +1,74 @@
+"""Adaptive rate clamp logic.
+
+The clamp controls the percentage of the provider budget that may be used.
+It adjusts in 10%% steps between 50%% and 100%% with a 60 second cooldown
+between adjustments. Failures have twice the weight of successes (2x
+hysteresis) meaning it takes two successful adjustments to offset one
+failure.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Callable, Dict
+
+MIN_CLAMP = 0.5
+MAX_CLAMP = 1.0
+STEP = 0.1
+COOLDOWN = 60
+HYSTERESIS = 2  # two successes required to offset one failure
+
+
+@dataclass
+class State:
+    clamp: float
+    last_adjust: float
+    counter: int
+
+
+class AdaptiveClamp:
+    """Adaptive clamp manager per provider."""
+
+    def __init__(self, *, time_func: Callable[[], float] | None = None) -> None:
+        self.time = time_func or time.time
+        self.states: Dict[str, State] = {}
+
+    # Security: No external input is trusted; provider names are assumed internal.
+    def adjust(self, provider: str, success: bool) -> float:
+        """Adjust clamp for a provider based on success/failure outcome.
+
+        Parameters
+        ----------
+        provider:
+            Provider name.
+        success:
+            ``True`` if the last call succeeded, ``False`` for failures.
+
+        Returns
+        -------
+        float
+            The new clamp value for the provider.
+        """
+
+        now = self.time()
+        state = self.states.get(provider)
+        if state is None:
+            state = State(clamp=MAX_CLAMP, last_adjust=now - COOLDOWN, counter=0)
+            self.states[provider] = state
+
+        state.counter += 1 if success else -2
+
+        if now - state.last_adjust < COOLDOWN:
+            return state.clamp
+
+        if state.counter <= -HYSTERESIS:
+            state.clamp = max(MIN_CLAMP, state.clamp - STEP)
+            state.counter = 0
+            state.last_adjust = now
+        elif state.counter >= HYSTERESIS:
+            state.clamp = min(MAX_CLAMP, state.clamp + STEP)
+            state.counter = 0
+            state.last_adjust = now
+
+        return state.clamp

--- a/backend/app/rate_limiting/token_bucket.py
+++ b/backend/app/rate_limiting/token_bucket.py
@@ -1,0 +1,89 @@
+"""Token bucket rate limiter with Redis backend and local fallback.
+
+This module implements a simple token bucket algorithm. Tokens are stored in
+Redis for cross-process coordination. When Redis is unavailable, an
+in-process dictionary is used as a fallback to avoid unlimited requests.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Callable, Dict, Tuple
+
+from redis import Redis
+from redis.exceptions import RedisError
+
+
+class TokenBucket:
+    """Redis-backed token bucket with in-process fallback.
+
+    Parameters
+    ----------
+    redis_client:
+        Redis connection used for shared token storage.
+    capacity:
+        Maximum number of tokens that can be stored in the bucket.
+    refill_rate:
+        Number of tokens added per second.
+    time_func:
+        Optional time provider for testing; defaults to :func:`time.time`.
+    """
+
+    def __init__(
+        self,
+        redis_client: Redis,
+        capacity: int,
+        refill_rate: float,
+        *,
+        time_func: Callable[[], float] | None = None,
+    ) -> None:
+        self.redis = redis_client
+        self.capacity = capacity
+        self.refill_rate = refill_rate
+        self.time = time_func or time.time
+        self.local_buckets: Dict[str, Tuple[float, float]] = {}
+
+    # Security: No secrets stored; fallback prevents unlimited calls on Redis outage.
+    def acquire(self, key: str, tokens: int = 1) -> bool:
+        """Attempt to take tokens from the bucket.
+
+        Returns ``True`` if enough tokens were available, ``False`` otherwise.
+        On Redis errors the function falls back to a process-local bucket.
+        """
+
+        now = self.time()
+        try:
+            data = self.redis.get(key)
+            if data is None:
+                available = self.capacity
+                last = now
+            else:
+                if isinstance(data, bytes):
+                    data = data.decode("utf-8")
+                available, last = json.loads(data)
+            available = float(available)
+            last = float(last)
+
+            delta = max(0.0, now - last) * self.refill_rate
+            available = min(self.capacity, available + delta)
+            allowed = available >= tokens
+            if allowed:
+                available -= tokens
+            self.redis.set(key, json.dumps([available, now]))
+            return allowed
+        except RedisError:
+            # Fallback to in-process bucket on Redis failure
+            return self._acquire_local(key, now, tokens)
+
+    def _acquire_local(self, key: str, now: float, tokens: int) -> bool:
+        """Local in-memory bucket used when Redis is unavailable."""
+
+        available, last = self.local_buckets.get(key, (self.capacity, now))
+        delta = max(0.0, now - last) * self.refill_rate
+        available = min(self.capacity, available + delta)
+        allowed = available >= tokens
+        if allowed:
+            available -= tokens
+        self.local_buckets[key] = (available, now)
+        return allowed

--- a/backend/tests/unit/test_rate_limiting.py
+++ b/backend/tests/unit/test_rate_limiting.py
@@ -1,0 +1,52 @@
+
+from redis.exceptions import RedisError
+
+from app.rate_limiting import AdaptiveClamp, acquire, adjust_clamp, init
+
+
+def _time_controller(start: float = 0.0):
+    current = {"value": start}
+
+    def now() -> float:
+        return current["value"]
+
+    def advance(seconds: float) -> None:
+        current["value"] += seconds
+
+    return now, advance
+
+
+def test_token_bucket_acquire(fake_redis):
+    now, advance = _time_controller()
+    init(fake_redis, capacity=1, refill_rate=1, time_func=now)
+    assert acquire("cg", "/foo")
+    assert not acquire("cg", "/foo")
+    advance(1)
+    assert acquire("cg", "/foo")
+
+
+def test_redis_failure_fallback():
+    class FailingRedis:
+        def get(self, key):  # pragma: no cover - trivial
+            raise RedisError("boom")
+
+        def set(self, *args, **kwargs):  # pragma: no cover - trivial
+            raise RedisError("boom")
+
+    now, advance = _time_controller()
+    init(FailingRedis(), capacity=1, refill_rate=1, time_func=now)
+    assert acquire("cg", "/bar")
+    assert not acquire("cg", "/bar")
+    advance(1)
+    assert acquire("cg", "/bar")
+
+
+def test_clamp_hysteresis(monkeypatch):
+    now, advance = _time_controller()
+    clamp = AdaptiveClamp(time_func=now)
+    monkeypatch.setattr("app.rate_limiting._clamp", clamp)
+
+    assert adjust_clamp("cg", success=False) == 0.9
+    assert adjust_clamp("cg", success=True) == 0.9
+    advance(60)
+    assert adjust_clamp("cg", success=True) == 1.0


### PR DESCRIPTION
## Summary
- implement Redis-backed token bucket with local fallback for rate limiting
- add adaptive clamp logic with 50-100% range, 10% steps, 60s cooldown and 2x hysteresis
- expose `acquire(provider, route)` and `adjust_clamp(provider, success)` APIs
- test token acquisition, Redis outage fallback, and clamp hysteresis

## Testing
- `make check`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c7546fc3488322bb6f518891d642e4