### PR TITLE
feat: implement rate limiting circuit breaker

### DIFF
--- a/backend/app/rate_limiting/__init__.py
+++ b/backend/app/rate_limiting/__init__.py
@@ -7,7 +7,19 @@ from typing import Callable, Optional
 from redis import Redis
 
 from .adaptive_clamps import AdaptiveClamp
+from .circuit_breaker import CircuitBreaker, CircuitBreakerOpen, CircuitState
 from .token_bucket import TokenBucket
+
+__all__ = [
+    "AdaptiveClamp",
+    "CircuitBreaker",
+    "CircuitBreakerOpen",
+    "CircuitState",
+    "TokenBucket",
+    "init",
+    "acquire",
+    "adjust_clamp",
+]
 
 _bucket: Optional[TokenBucket] = None
 _clamp = AdaptiveClamp()

--- a/backend/app/rate_limiting/circuit_breaker.py
+++ b/backend/app/rate_limiting/circuit_breaker.py
@@ -1,0 +1,121 @@
+"""Generic circuit breaker implementation.
+
+This module provides a reusable circuit breaker with the classic CLOSED →
+OPEN → HALF_OPEN transitions. It supports a probe interval, manual operator
+controls, and raises :class:`CircuitBreakerOpen` when the breaker blocks calls.
+"""
+
+from __future__ import annotations
+
+import time
+from enum import Enum
+from typing import Awaitable, Callable, Generic, Optional, TypeVar
+
+
+class CircuitBreakerOpen(Exception):
+    """Raised when the circuit breaker is open and calls are blocked."""
+
+
+class CircuitState(str, Enum):
+    """Possible circuit breaker states."""
+
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+T = TypeVar("T")
+
+
+class CircuitBreaker(Generic[T]):
+    """Circuit breaker controlling calls to unreliable services.
+
+    Parameters
+    ----------
+    failure_threshold:
+        Consecutive failures required to open the circuit.
+    probe_interval:
+        Seconds to wait before allowing a probe call after opening.
+    time_func:
+        Optional time provider for tests; defaults to :func:`time.monotonic`.
+    """
+
+    def __init__(
+        self,
+        failure_threshold: int,
+        probe_interval: float,
+        *,
+        time_func: Callable[[], float] | None = None,
+    ) -> None:
+        self.failure_threshold = failure_threshold
+        self.probe_interval = probe_interval
+        self.time = time_func or time.monotonic
+        self._failures = 0
+        self._state: CircuitState = CircuitState.CLOSED
+        self._opened_at: Optional[float] = None
+
+    @property
+    def state(self) -> CircuitState:
+        """Return the current state."""
+
+        return self._state
+
+    # Hooks for Operator Console
+    def force_open(self) -> None:
+        """Manually open the circuit via operator control."""
+
+        self._state = CircuitState.OPEN
+        self._opened_at = self.time()
+
+    def force_close(self) -> None:
+        """Manually close the circuit and reset counters."""
+
+        self._state = CircuitState.CLOSED
+        self._failures = 0
+        self._opened_at = None
+
+    async def call(self, func: Callable[[], Awaitable[T]]) -> T:
+        """Execute ``func`` respecting circuit breaker state.
+
+        Raises
+        ------
+        CircuitBreakerOpen
+            If the circuit breaker is open or probing interval has not elapsed.
+        Exception
+            Propagates errors from ``func``.
+        """
+
+        now = self.time()
+        if self._state is CircuitState.OPEN:
+            if (
+                self._opened_at is not None
+                and now - self._opened_at >= self.probe_interval
+            ):
+                self._state = CircuitState.HALF_OPEN
+            else:
+                raise CircuitBreakerOpen("circuit breaker open")
+
+        try:
+            result = await func()
+        except Exception:
+            self._failures += 1
+            if (
+                self._state is CircuitState.HALF_OPEN
+                or self._failures >= self.failure_threshold
+            ):
+                self._state = CircuitState.OPEN
+                self._opened_at = now
+            raise
+        else:
+            self._failures = 0
+            self._state = CircuitState.CLOSED
+            self._opened_at = None
+            return result
+
+
+# Security: no secrets stored; manual controls allow Operator Console oversight.
+__all__ = [
+    "CircuitBreaker",
+    "CircuitBreakerOpen",
+    "CircuitState",
+]

--- a/backend/tests/unit/test_rate_limiting_circuit_breaker.py
+++ b/backend/tests/unit/test_rate_limiting_circuit_breaker.py
@@ -1,0 +1,81 @@
+import pytest
+from app.rate_limiting.circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerOpen,
+    CircuitState,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_transitions_success():
+    now = 0.0
+
+    def time_func() -> float:
+        return now
+
+    breaker = CircuitBreaker(
+        failure_threshold=1, probe_interval=10, time_func=time_func
+    )
+
+    async def fail():
+        raise RuntimeError("boom")
+
+    async def success():
+        return "ok"
+
+    with pytest.raises(RuntimeError):
+        await breaker.call(fail)
+    assert breaker.state is CircuitState.OPEN
+
+    with pytest.raises(CircuitBreakerOpen):
+        await breaker.call(success)
+
+    now += 11
+    result = await breaker.call(success)
+    assert result == "ok"
+    assert breaker.state is CircuitState.CLOSED
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_probe_failure_reopens():
+    now = 0.0
+
+    def time_func() -> float:
+        return now
+
+    breaker = CircuitBreaker(failure_threshold=1, probe_interval=5, time_func=time_func)
+
+    async def fail():
+        raise ValueError("nope")
+
+    with pytest.raises(ValueError):
+        await breaker.call(fail)
+    assert breaker.state is CircuitState.OPEN
+
+    now += 6
+    with pytest.raises(ValueError):
+        await breaker.call(fail)
+    assert breaker.state is CircuitState.OPEN
+
+    with pytest.raises(CircuitBreakerOpen):
+        await breaker.call(fail)
+
+
+@pytest.mark.asyncio
+async def test_manual_open_close():
+    breaker = CircuitBreaker(failure_threshold=2, probe_interval=30)
+
+    async def success():
+        return 1
+
+    breaker.force_open()
+    assert breaker.state is CircuitState.OPEN
+    with pytest.raises(CircuitBreakerOpen):
+        await breaker.call(success)
+
+    breaker.force_close()
+    result = await breaker.call(success)
+    assert result == 1
+    assert breaker.state is CircuitState.CLOSED


### PR DESCRIPTION
## Summary
- add generic circuit breaker with CLOSED/OPEN/HALF_OPEN states and manual controls
- expose circuit breaker in rate limiting package
- test circuit breaker transitions and operator overrides

## Testing
- `make check`
- `make test` *(fails: vitest not found)*
- `pytest backend/tests/unit/test_rate_limiting_circuit_breaker.py --no-cov -q`

------
https://chatgpt.com/codex/tasks/task_e_68c75a032c408322871985879df181ad