### PR TITLE
feat(rate-limiting): add provider budgets and retry headers

### DIFF
--- a/backend/app/rate_limiting/__init__.py
+++ b/backend/app/rate_limiting/__init__.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Callable, Optional
+from typing import Callable, Dict, Optional
 
 from redis import Redis
 
 from .adaptive_clamps import AdaptiveClamp
 from .circuit_breaker import CircuitBreaker, CircuitBreakerOpen, CircuitState
 from .token_bucket import TokenBucket
+from .provider_budgets import DEFAULT_BUDGETS, ProviderBudget
 
 __all__ = [
     "AdaptiveClamp",
@@ -21,46 +22,72 @@ __all__ = [
     "adjust_clamp",
 ]
 
-_bucket: Optional[TokenBucket] = None
+_buckets: Dict[tuple[str, str], TokenBucket] = {}
+_budgets: Dict[str, ProviderBudget] = DEFAULT_BUDGETS.copy()
 _clamp = AdaptiveClamp()
 
 
 def init(
     redis_client: Redis,
-    capacity: int,
-    refill_rate: float,
+    budgets: Dict[str, ProviderBudget] | None = None,
     *,
     time_func: Callable[[], float] | None = None,
 ) -> None:
-    """Initialize token bucket with Redis client.
+    """Initialize token buckets for all providers.
 
-    Parameters
-    ----------
-    redis_client:
-        Redis connection used for token storage.
-    capacity:
-        Maximum number of tokens in each bucket.
-    refill_rate:
-        Tokens added per second.
-    time_func:
-        Optional time provider for tests.
+    ``budgets`` may override the default :data:`DEFAULT_BUDGETS` mapping.
     """
 
-    global _bucket
-    _bucket = TokenBucket(redis_client, capacity, refill_rate, time_func=time_func)
+    global _buckets, _budgets
+    _buckets = {}
+    _budgets = budgets or DEFAULT_BUDGETS
+    for provider, budget in _budgets.items():
+        if budget.per_sec:
+            _buckets[(provider, "per_sec")] = TokenBucket(
+                redis_client,
+                capacity=float(budget.per_sec),
+                refill_rate=float(budget.per_sec),
+                time_func=time_func,
+            )
+        if budget.per_min:
+            _buckets[(provider, "per_min")] = TokenBucket(
+                redis_client,
+                capacity=float(budget.per_min),
+                refill_rate=float(budget.per_min) / 60.0,
+                time_func=time_func,
+            )
+        if budget.per_day:
+            _buckets[(provider, "per_day")] = TokenBucket(
+                redis_client,
+                capacity=float(budget.per_day),
+                refill_rate=float(budget.per_day) / 86400.0,
+                time_func=time_func,
+            )
 
 
 # Security: Public API to acquire tokens. Relies on prior :func:`init` call.
-def acquire(provider: str, route: str, tokens: int = 1) -> bool:
-    """Acquire tokens for ``provider`` and ``route``.
+def acquire(provider: str, route: str, tokens: float = 1.0) -> tuple[bool, float]:
+    """Acquire tokens for ``provider``.
 
-    Returns ``True`` if the call is allowed, ``False`` otherwise.
+    Returns tuple of ``(allowed, retry_after_seconds)``.
     """
 
-    if _bucket is None:  # pragma: no cover - defensive
-        raise RuntimeError("token bucket not initialized")
-    key = f"{provider}:{route}"
-    return _bucket.acquire(key, tokens)
+    if not _buckets:  # pragma: no cover - defensive
+        raise RuntimeError("token buckets not initialized")
+
+    clamp = _clamp.get(provider)
+    cost = tokens / clamp if clamp > 0 else float("inf")
+    retry_after = 0.0
+    allowed = True
+    for (prov, period), bucket in _buckets.items():
+        if prov != provider:
+            continue
+        key = f"{provider}:{period}"
+        ok, wait = bucket.acquire(key, cost)
+        if not ok:
+            allowed = False
+            retry_after = max(retry_after, wait)
+    return allowed, retry_after
 
 
 def adjust_clamp(provider: str, success: bool) -> float:

--- a/backend/app/rate_limiting/adaptive_clamps.py
+++ b/backend/app/rate_limiting/adaptive_clamps.py
@@ -72,3 +72,9 @@ class AdaptiveClamp:
             state.last_adjust = now
 
         return state.clamp
+
+    def get(self, provider: str) -> float:
+        """Return current clamp for ``provider`` without modifying state."""
+
+        state = self.states.get(provider)
+        return state.clamp if state else MAX_CLAMP

--- a/backend/app/rate_limiting/provider_budgets.py
+++ b/backend/app/rate_limiting/provider_budgets.py
@@ -1,0 +1,24 @@
+"""Default provider rate limit budgets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass(frozen=True)
+class ProviderBudget:
+    """Ceiling definitions for a provider."""
+
+    per_sec: Optional[float] = None
+    per_min: Optional[float] = None
+    per_day: Optional[float] = None
+
+
+DEFAULT_BUDGETS: Dict[str, ProviderBudget] = {
+    "coingecko": ProviderBudget(per_sec=5, per_min=30),
+    "etherscan": ProviderBudget(per_sec=5, per_day=100_000),
+    "mempool_space": ProviderBudget(per_sec=1),
+    "fx": ProviderBudget(per_min=10),
+}
+"""Default provider budgets used when none supplied."""

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
-from app.main import app  # noqa: E402
+from app.main import app, rate_limiter  # noqa: E402
 
 FIXTURES_PATH = Path(__file__).parent / "fixtures"
 PROVIDER_FIXTURES_PATH = FIXTURES_PATH / "providers"
@@ -19,7 +19,11 @@ PROVIDER_FIXTURES_PATH = FIXTURES_PATH / "providers"
 def client() -> TestClient:  # pragma: no cover
     """FastAPI test client."""
     with TestClient(app) as test_client:
-        yield test_client
+        app.dependency_overrides[rate_limiter] = lambda request: None
+        try:
+            yield test_client
+        finally:
+            app.dependency_overrides.clear()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- add default budgets for coingecko, etherscan, mempool.space, and fx providers
- integrate budgets with token bucket and clamp logic, returning 429 with Retry-After
- add tests covering Retry-After header and per-provider budget tracking

## Testing
- `make check`
- `pytest backend/tests/unit/test_main.py::test_retry_after_header backend/tests/unit/test_main.py::test_separate_provider_budgets`
- `pytest backend/tests` *(fails: KeyError 'eth_gas' and token buckets not initialized in integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c75d96f9888322b77dbbf95f4a8695