### PR TITLE
feat(breaker): freeze on 403 with operator reset

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -332,6 +332,106 @@
         }
       }
     },
+    "/fx/{base}/{quote}": {
+      "get": {
+        "summary": "Fx Rate",
+        "operationId": "fx_rate_fx__base___quote__get",
+        "parameters": [
+          {
+            "name": "base",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]{3}$",
+              "title": "Base"
+            }
+          },
+          {
+            "name": "quote",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]{3}$",
+              "title": "Quote"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FXRate"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Payload Too Large",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Unsupported Media Type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/onchain/eth/gas": {
       "get": {
         "summary": "Onchain Eth Gas",
@@ -461,6 +561,110 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/operator/breaker/{provider}/reset": {
+      "post": {
+        "summary": "Operator Breaker Reset",
+        "operationId": "operator_breaker_reset_operator_breaker__provider__reset_post",
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9_-]{1,64}$",
+              "title": "Provider"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Payload Too Large",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Unsupported Media Type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -635,6 +839,39 @@
         ],
         "title": "ErrorResponse",
         "description": "Structured error for 4xx/5xx responses."
+      },
+      "FXRate": {
+        "properties": {
+          "base": {
+            "type": "string",
+            "title": "Base"
+          },
+          "quote": {
+            "type": "string",
+            "title": "Quote"
+          },
+          "rate": {
+            "type": "number",
+            "title": "Rate"
+          },
+          "asof": {
+            "type": "number",
+            "title": "Asof"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source"
+          }
+        },
+        "type": "object",
+        "required": [
+          "base",
+          "quote",
+          "rate",
+          "asof",
+          "source"
+        ],
+        "title": "FXRate"
       },
       "GasPrices": {
         "properties": {

--- a/backend/tests/unit/test_operator_breaker_reset.py
+++ b/backend/tests/unit/test_operator_breaker_reset.py
@@ -1,0 +1,53 @@
+import httpx
+import pytest
+
+from app.main import app, rate_limiter
+from app.rate_limiting import CircuitBreaker, CircuitState, register_breaker
+
+pytestmark = pytest.mark.unit
+
+
+class Resp:
+    status_code = 403
+
+
+class ForbiddenError(Exception):
+    def __init__(self) -> None:
+        self.response = Resp()
+
+
+@pytest.mark.asyncio
+async def test_operator_reset_endpoint():
+    breaker = CircuitBreaker(failure_threshold=1, probe_interval=1)
+    register_breaker("testprov", breaker)
+
+    async def forbidden():
+        raise ForbiddenError()
+
+    with pytest.raises(ForbiddenError):
+        await breaker.call(forbidden, trace_id="tid")
+    assert breaker.state is CircuitState.OPEN
+
+    app.dependency_overrides[rate_limiter] = lambda request: None
+    async with httpx.AsyncClient(app=app, base_url="http://test") as ac:
+        res = await ac.post(
+            "/operator/breaker/testprov/reset",
+            headers={"Authorization": "Bearer operator", "X-Trace-Id": "tid"},
+        )
+    app.dependency_overrides.clear()
+
+    assert res.status_code == 200
+    assert breaker.state is CircuitState.CLOSED
+
+
+@pytest.mark.asyncio
+async def test_operator_reset_auth_required():
+    breaker = CircuitBreaker(failure_threshold=1, probe_interval=1)
+    register_breaker("unauth", breaker)
+
+    app.dependency_overrides[rate_limiter] = lambda request: None
+    async with httpx.AsyncClient(app=app, base_url="http://test") as ac:
+        res = await ac.post("/operator/breaker/unauth/reset")
+    app.dependency_overrides.clear()
+
+    assert res.status_code == 401


### PR DESCRIPTION
## Summary
- freeze circuit breakers on 403 errors until operator reset
- add operator breaker reset endpoint secured by auth stub
- log breaker freeze/unfreeze events with trace_id
- test breaker freeze behavior and operator reset path

## Testing
- `make check`
- `make test` *(fails: vitest not found; backend test_db error)*

------
https://chatgpt.com/codex/tasks/task_e_68c76b5d582883229ded13a5ad97d6ba